### PR TITLE
Fix for Fedora (> 34) based systems

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,5 +2,5 @@
 
 devture_timesync_installation_enabled: true
 
-devture_timesync_ntpd_package: "{{ 'systemd-timesyncd' if (ansible_os_family == 'RedHat' and ansible_distribution_major_version | int > 7) or (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version | int > 18) else ('systemd' if ansible_os_family == 'Suse' else 'ntp') }}"
+devture_timesync_ntpd_package: "{{ 'systemd-timesyncd' if (ansible_os_family == 'RedHat' and ansible_distribution_major_version | int > 7 and not ansible_distribution == 'Fedora') or (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version | int > 18) else ('systemd' if ansible_os_family == 'Suse' or ansible_distribution == 'Fedora' else 'ntp') }}"
 devture_timesync_ntpd_service: "{{ 'systemd-timesyncd' if (ansible_os_family == 'RedHat' and ansible_distribution_major_version | int > 7) or (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version | int > 18) or ansible_distribution == 'Archlinux' or ansible_os_family == 'Suse' else ('ntpd' if ansible_os_family == 'RedHat' else 'ntp') }}"


### PR DESCRIPTION
While trying to run spantaleev/matrix-docker-ansible-deploy on my Fedora based server I found out this ansible role fails.
Reason: Fedora ( with version > 34, i.e. all currently supported versions) includes timesyncd in the systemd package instead of a separate systemd-timesyncd package.
Even though it belongs to ansible_os_family RedHat it still behaves like Suse does in this case.
This change fixes this.
This also leads to spantaleev/matrix-docker-ansible-deploy working with Fedora based servers.