### PR TITLE
Changed used variables to fix for Fedora & Suse

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,5 +2,5 @@
 
 devture_timesync_installation_enabled: true
 
-devture_timesync_ntpd_package: "{{ 'systemd-timesyncd' if (ansible_os_family == 'RedHat' and ansible_distribution_major_version | int > 7 and not ansible_distribution == 'Fedora') or (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version | int > 18) else ('systemd' if ansible_os_family in ['Suse', 'Fedora', 'Archlinux'] else 'ntp') }}"
-devture_timesync_ntpd_service: "{{ 'systemd-timesyncd' if (ansible_os_family == 'RedHat' and ansible_distribution_major_version | int > 7) or (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version | int > 18) or (ansible_distribution in ['Suse', 'Archlinux']) else ('ntpd' if ansible_os_family == 'RedHat' else 'ntp') }}"
+devture_timesync_ntpd_package: "{{ 'systemd-timesyncd' if (ansible_os_family == 'RedHat' and ansible_distribution_major_version | int > 7 and not ansible_distribution == 'Fedora') or (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version | int > 18) else ('systemd' if ansible_os_family in ['Suse', 'Archlinux'] or ansible_distribution == 'Fedora' else 'ntp') }}"
+devture_timesync_ntpd_service: "{{ 'systemd-timesyncd' if (ansible_os_family == 'RedHat' and ansible_distribution_major_version | int > 7) or (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version | int > 18) or (ansible_os_family in ['Suse', 'Archlinux']) else ('ntpd' if ansible_os_family == 'RedHat' else 'ntp') }}"


### PR DESCRIPTION
Fixes this role working on Fedora & Suse, because incorrect ansible facts were compared.

'Fedora' is a ansible_distribution list, 'Suse' in os_family (would be 'SUSE' in distribution)

This is according to https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_conditionals.html
